### PR TITLE
rename list_operations to avoid OpenHands MCP bugs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,13 +25,6 @@ jobs:
       - name: Set up Python
         run: uv python install ${{ env.DEFAULT_PYTHON }}
 
-      - name: Cache venv
-        id: cache-venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ github.job }}-${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-${{ hashFiles('uv.lock') }}
-
       - name: Install dependencies
         run: uv sync --group dev
 
@@ -51,13 +44,6 @@ jobs:
 
       - name: Set up Python
         run: uv python install ${{ env.DEFAULT_PYTHON }}
-
-      - name: Cache venv
-        id: cache-venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ github.job }}-${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -88,13 +74,6 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - name: Cache venv
-        id: cache-venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ github.job }}-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
-  
       - name: Install dependencies
         run: uv sync --group dev
 

--- a/contree_mcp/tools/list_operations.py
+++ b/contree_mcp/tools/list_operations.py
@@ -8,10 +8,11 @@ class ListOperationsOutput(BaseModel):
     operations: list[OperationSummary] = Field(description="List of operations")
 
 
+# noinspection PyShadowingBuiltins
 async def list_operations(
     limit: int = 100,
     status: OperationStatus | None = None,
-    kind: OperationKind | None = None,
+    type: OperationKind | None = None,
     since: str | None = None,
 ) -> ListOperationsOutput:
     """
@@ -39,7 +40,7 @@ async def list_operations(
     operations = await client.list_operations(
         limit=limit,
         status=status,
-        kind=kind,
+        kind=type,
         since=since,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "contree-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server for Contree container management system"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
openhands's `DiscriminatedUnionMixin` generates `MCPListOperationsAction` with a computed_field `kind` that overrides the parent class field, causing TypeError on any Pydantic version.

Workaround for:
- OpenHands/software-agent-sdk#1555
- OpenHands/software-agent-sdk#1779
