### PR TITLE
User feedback fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+env:
+  DEFAULT_PYTHON: "3.12"
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install ${{ env.DEFAULT_PYTHON }}
+
+      - name: Set version from tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          uv version "$VERSION"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ token = <TOKEN HERE>
 
 #### Claude Code
 
-Add to `~/.claude/settings.json`:
-
-```json
-{"mcpServers": {"contree": {"command": "uvx", "args": ["contree-mcp"]}}}
+```bash
+claude mcp add --transport stdio contree -- $(which uvx) contree-mcp
 ```
 
 Restart Claude Code or run `/mcp` to verify.

--- a/contree_mcp/docs.py
+++ b/contree_mcp/docs.py
@@ -708,7 +708,7 @@ EOF</pre>
         </div>
         <div class="tab-content active" data-mode="stdio">
           <p>Using CLI:</p>
-<pre>claude mcp add contree -- uvx contree-mcp</pre>
+<pre>claude mcp add --transport stdio contree -- $(which uvx) contree-mcp</pre>
           <p>Or add to config file (<code>~/.claude.json</code> or <code>.mcp.json</code>):</p>
 <pre>{{
   "mcpServers": {{

--- a/contree_mcp/tools/rsync.py
+++ b/contree_mcp/tools/rsync.py
@@ -34,6 +34,8 @@ async def rsync(
     source_path = Path(source).expanduser()
     if not source_path.is_absolute():
         raise ValueError(f"source must be an absolute path, got: {source}")
+    if not source_path.exists():
+        raise ValueError(f"source path does not exist: {source_path}")
 
     destination = destination.rstrip("/")
     exclude = exclude or []

--- a/docs/integration/configuration.md
+++ b/docs/integration/configuration.md
@@ -56,17 +56,8 @@ With credentials stored in `~/.config/contree/mcp.ini`, MCP client configs are m
 
 ### Claude Code
 
-`~/.claude/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "contree": {
-      "command": "uvx",
-      "args": ["contree-mcp"]
-    }
-  }
-}
+```bash
+claude mcp add --transport stdio contree -- $(which uvx) contree-mcp
 ```
 
 ### HTTP Mode

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,17 +31,8 @@ token = <TOKEN HERE>
 ::::{tab-set}
 
 :::{tab-item} Claude Code
-Add to `~/.claude/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "contree": {
-      "command": "uvx",
-      "args": ["contree-mcp"]
-    }
-  }
-}
+```bash
+claude mcp add --transport stdio contree -- $(which uvx) contree-mcp
 ```
 
 Restart Claude Code or run `/mcp` to verify.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -156,7 +156,8 @@ class TestTagImage(TestCase):
     def fake_responses(self) -> FakeResponses:
         return {
             "PATCH /images/img-123/tag": FakeResponse(body=make_image(uuid="img-123", tag="myapp:v1").model_dump()),
-            "DELETE /images/img-123/tag": FakeResponse(body=make_image(uuid="img-123", tag=None).model_dump()),
+            "DELETE /images/img-123/tag": FakeResponse(body={}),
+            "GET /inspect/img-123/": FakeResponse(body=make_image(uuid="img-123", tag=None).model_dump()),
         }
 
     @pytest.mark.asyncio

--- a/tests/tools/test_rsync.py
+++ b/tests/tools/test_rsync.py
@@ -20,6 +20,11 @@ class TestRsyncValidation(TestCase):
         with pytest.raises(ValueError, match="absolute path"):
             await rsync(source="relative/path", destination="/app")
 
+    @pytest.mark.asyncio
+    async def test_rejects_nonexistent_source_path(self):
+        with pytest.raises(ValueError, match="source path does not exist"):
+            await rsync(source="/nonexistent/path", destination="/app")
+
 
 class TestRsync(TestCase):
     @pytest.fixture

--- a/tests/tools/test_rsync.py
+++ b/tests/tools/test_rsync.py
@@ -21,9 +21,10 @@ class TestRsyncValidation(TestCase):
             await rsync(source="relative/path", destination="/app")
 
     @pytest.mark.asyncio
-    async def test_rejects_nonexistent_source_path(self):
+    async def test_rejects_nonexistent_source_path(self, tmp_path: Path):
+        nonexistent = str(tmp_path / "nonexistent")
         with pytest.raises(ValueError, match="source path does not exist"):
-            await rsync(source="/nonexistent/path", destination="/app")
+            await rsync(source=nonexistent, destination="/app")
 
 
 class TestRsync(TestCase):

--- a/tests/tools/test_set_tag.py
+++ b/tests/tools/test_set_tag.py
@@ -42,7 +42,8 @@ class TestSetTagRemove(TestCase):
     @pytest.fixture
     def fake_responses(self) -> FakeResponses:
         return {
-            "DELETE /images/{uuid}/tag": FakeResponse(
+            "DELETE /images/{uuid}/tag": FakeResponse(body={}),
+            "GET /inspect/{uuid}/": FakeResponse(
                 body=Image(uuid="img-1", tag=None, created_at="2024-01-01T00:00:00Z")
             ),
         }

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "contree-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the MCP client and tools, along with documentation updates for easier integration. The main changes focus on improving operation cancellation behavior, updating CLI documentation for Claude Code, and enhancing error handling in tools.

Operation handling improvements:

* Explicitly cancels backend operations not yet completed when waiting in `mode="any"` in `wait_operations`, ensuring no lingering operations remain.
* Adds exception suppression during operation cancellation in both `wait_operations` and `wait_for_operation` for robustness. (`contree_mcp/tools/wait_operations.py`, `contree_mcp/client.py`)

Documentation and integration updates:

* Updates CLI instructions for adding MCP servers in Claude Code, replacing manual JSON configuration with a single `claude mcp add` command in multiple documentation files.

Tool and client enhancements:

* Adds validation for existence of source paths in `rsync`, raising an error if the source does not exist, and adds corresponding test coverage.
* Refactors image untagging logic in the client to use streaming requests and fetch the updated image, with corresponding updates to tests.