### PR TITLE
Add EAP relates instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Every container is isolated. Every image is immutable. Branching is cheap. Mista
 
 ## Quick Setup
 
-### 1. Create Config File
+### 1. Get an API Token
+
+Contree is in **Early Access**. To get an API token, fill out the request form at [contree.dev](https://contree.dev).
+
+### 2. Create Config File
 
 Store credentials in `~/.config/contree/mcp.ini`:
 
@@ -28,7 +32,7 @@ url = https://contree.dev/
 token = <TOKEN HERE>
 ```
 
-### 2. Configure Your MCP Client
+### 3. Configure Your MCP Client
 
 #### Claude Code
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,10 +9,7 @@ Run your first container in 5 minutes.
 
 ### Getting an API Token
 
-1. Visit [Nebius Cloud Console](https://console.nebius.cloud/)
-2. Navigate to **Settings** → **API Tokens**
-3. Click **Create Token** and copy the generated value
-4. Store securely—tokens are shown only once
+Contree is in **Early Access**. To get an API token, fill out the request form at [contree.dev](https://contree.dev).
 
 ## Installation
 


### PR DESCRIPTION
This pull request updates the documentation to reflect the new process for obtaining an API token, aligning instructions across both the `README.md` and `docs/quickstart.md` files. The most important changes are grouped below:

API Token Acquisition Process:

* Updated the instructions in `README.md` and `docs/quickstart.md` to inform users that Contree is in Early Access and API tokens are now obtained by filling out a request form at [contree.dev](https://contree.dev), replacing previous directions for token acquisition. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R25) [[2]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL12-R12)

Documentation Structure:

* Adjusted the setup steps in `README.md` to add a new section for getting an API token, shifting the numbering of subsequent steps to accommodate this change. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R35)