### PR TITLE
Remove duplicated dev dependency block in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,20 +18,6 @@ dependencies = [
     "pydantic>=2.0.0",      # transitive dependency from mcp, so we have to use it and pin version here
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=8.0.0",
-    "pytest-asyncio>=0.23.0",
-    "mypy>=1.8.0",
-    "ruff>=0.2.0",
-    "sphinx>=7.0.0",
-    "furo>=2024.0.0",
-    "myst-parser>=3.0.0",
-    "sphinx-design>=0.5.0",
-    "sphinx-copybutton>=0.5.0",
-    "sphinxcontrib-mermaid>=0.9.0",
-]
-
 [project.scripts]
 contree-mcp = "contree_mcp.__main__:main"
 


### PR DESCRIPTION
## Summary

\`[project.optional-dependencies] dev\` and \`[dependency-groups] dev\` both declare the same set, but with version drift:

| Tool | optional-deps | dependency-groups |
|---|---|---|
| pytest | \`>=8.0.0\` | \`>=9.0.2\` |
| pytest-asyncio | \`>=0.23.0\` | \`>=1.3.0\` |
| mypy | \`>=1.8.0\` | \`>=1.19.1\` |
| ruff | \`>=0.2.0\` | \`>=0.14.13\` |

CI runs \`uv sync --group dev\`, which reads the latter. The legacy block silently rotted and confuses contributors who look at it first.

This PR drops the legacy block. \`uv sync --group dev\` users are unaffected.

## Test plan

- [x] \`uv sync --group dev\` succeeds on a clean checkout
- [x] \`uv run pytest tests/ -q\` — 516 passed
- [x] \`uv run ruff check contree_mcp\` — clean
- [x] \`uv run mypy contree_mcp\` — clean

## Notes for contributors

If anyone was using \`pip install -e .[dev]\`, switch to \`uv sync\` or use pip's PEP 735 dependency-group support (\`pip install --group dev\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)