### PR TITLE
Add --version / -V flag to contree-mcp CLI

### DIFF
--- a/contree_mcp/__main__.py
+++ b/contree_mcp/__main__.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.metadata
 import logging
 import os
 import sys
@@ -7,7 +8,19 @@ from contree_mcp.arguments import Parser
 from contree_mcp.server import amain
 
 
+def _print_version_and_exit() -> None:
+    try:
+        version = importlib.metadata.version("contree-mcp")
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    print(f"contree-mcp {version}")
+    sys.exit(0)
+
+
 def main() -> None:
+    if any(arg in ("--version", "-V") for arg in sys.argv[1:]):
+        _print_version_and_exit()
+
     parser = Parser(
         config_files=[os.getenv("CONTREE_MCP_CONFIG", "~/.config/contree/mcp.ini")],
         auto_env_var_prefix="CONTREE_MCP_",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,6 +74,30 @@ class TestCLI:
         assert result.returncode == 0
         assert "usage:" in result.stdout.lower() or "--help" in result.stdout
 
+    def test_cli_version_long(self) -> None:
+        """Test that --version prints version and exits 0."""
+        result = subprocess.run(
+            [sys.executable, "-m", "contree_mcp", "--version"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert result.stdout.startswith("contree-mcp ")
+        assert result.stdout.strip() != "contree-mcp"
+        assert result.stdout.strip() != "contree-mcp unknown"
+
+    def test_cli_version_short(self) -> None:
+        """Test that -V is an alias for --version."""
+        result = subprocess.run(
+            [sys.executable, "-m", "contree_mcp", "-V"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert result.stdout.startswith("contree-mcp ")
+
     def test_cli_missing_required_token(self) -> None:
         """Test that missing required --token produces error."""
         # Clear env vars that could provide the token and config file


### PR DESCRIPTION
## Summary

\`contree-mcp --version\` currently fails with argclass's \"unrecognized argument\" error. This PR adds the standard \`--version\` / \`-V\` flag.

Implementation: intercept the flag in \`__main__.py\` before \`Parser.parse_args()\` so it works regardless of config-file state or token availability. Reads version via \`importlib.metadata.version(\"contree-mcp\")\` — already used in \`client.py:113\` for the User-Agent header.

## Behavior

\`\`\`bash
\$ contree-mcp --version
contree-mcp 0.1.1

\$ contree-mcp -V
contree-mcp 0.1.1
\`\`\`

Returns 0 in both cases. Falls back to \`contree-mcp unknown\` only if the package isn't discoverable via metadata.

## Test plan

- [x] \`contree-mcp --version\` prints version, exits 0
- [x] \`contree-mcp -V\` prints version, exits 0
- [x] Existing flag invocations unaffected (\`test_parser_*\`, \`test_cli_help\`, \`test_cli_missing_required_token\` all pass)
- [x] \`uv run pytest tests/ -q\` — 518 passed (516 before + 2 new)
- [x] \`uv run ruff check contree_mcp\` — clean
- [x] \`uv run mypy contree_mcp\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)