### PR TITLE
Add Makefile and simplify README dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: help install test test-verbose lint format typecheck check build clean
+
+help:  ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage: make <target>\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  %-14s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+install:  ## Install dev dependencies (uv sync --group dev)
+	uv sync --group dev
+
+test:  ## Run tests (quiet)
+	uv run pytest tests/ -q
+
+test-verbose:  ## Run tests (verbose)
+	uv run pytest tests/ -v
+
+lint:  ## Run ruff check
+	uv run ruff check contree_mcp
+
+format:  ## Run ruff format (auto-fix)
+	uv run ruff format contree_mcp
+	uv run ruff check contree_mcp --fix
+
+typecheck:  ## Run mypy
+	uv run mypy contree_mcp
+
+check: lint typecheck test  ## Run lint + typecheck + tests (CI-equivalent)
+
+build:  ## Build wheel + sdist
+	uv build
+
+clean:  ## Remove build artefacts and caches
+	rm -rf dist build *.egg-info .pytest_cache .mypy_cache .ruff_cache
+	find . -type d -name __pycache__ -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -344,49 +344,39 @@ Use this to rollback to any ancestor or understand how an image was created.
 **Requirements:** Python 3.10+
 
 ```bash
-# Clone and install in dev mode
 git clone https://github.com/nebius/contree-mcp.git
 cd contree-mcp
-uv sync --group dev
+make install
 ```
 
 ### Development Workflow
 
-Follow this sequence when making changes:
+```bash
+make check     # lint + typecheck + tests (run before pushing)
+make test      # tests only (quiet)
+make format    # auto-fix formatting and lint
+make help      # full target list
+```
 
-1. **Make code changes** - Edit files in `contree_mcp/`
+When making changes:
 
-2. **Run tests** - Ensure all tests pass
-   ```bash
-   uv run pytest tests/ -v
-   ```
+1. **Edit code** in `contree_mcp/`
+2. **Run `make check`** — must pass before opening a PR
+3. **Update documentation** if behavior changes:
+   - `README.md` — user-facing docs, examples, tool descriptions
+   - `llm.txt` — shared context for AI agents (architecture, class hierarchy, internals)
 
-3. **Run linter** - Fix any style issues
-   ```bash
-   uv run ruff check contree_mcp
-   uv run ruff format contree_mcp  # Auto-fix formatting
-   ```
+### Without `make`
 
-4. **Type check** (optional but recommended)
-   ```bash
-   uv run mypy contree_mcp
-   ```
-
-5. **Update documentation** - Keep docs in sync with code
-   - `README.md` - User-facing docs, examples, tool descriptions
-   - `llm.txt` - Shared context for AI agents (architecture, class hierarchy, internals)
-
-### Quick Commands
+If you'd rather not use `make`, the underlying `uv run` commands are:
 
 ```bash
-# Full validation cycle
-uv run pytest tests/ -q && uv run ruff check contree_mcp && echo "All checks passed"
-
-# Run specific test file
-uv run pytest tests/test_tools/test_run.py -v
-
-# Auto-fix linting issues
-uv run ruff check contree_mcp --fix
+uv sync --group dev                                    # install
+uv run pytest tests/ -q                                # test
+uv run ruff check contree_mcp                          # lint
+uv run ruff format contree_mcp                         # format
+uv run mypy contree_mcp                                # typecheck
+uv run pytest tests/tools/test_run_command.py -v       # single test file
 ```
 
 ### Testing GitHub Actions Locally


### PR DESCRIPTION
## Summary

The README dev section currently documents \`uv run pytest tests/ -v && uv run ruff check contree_mcp && ...\` as the dev loop — long-form, easy to mistype, no shared muscle memory across contributors.

This PR adds a Makefile that wraps the common \`uv run\` invocations, and reworks the README to lead with \`make check\` (the CI-equivalent local run).

## Targets

| Target | What it does |
|---|---|
| \`help\` | Print target list |
| \`install\` | \`uv sync --group dev\` |
| \`test\` | \`uv run pytest tests/ -q\` |
| \`test-verbose\` | \`uv run pytest tests/ -v\` |
| \`lint\` | \`uv run ruff check contree_mcp\` |
| \`format\` | \`uv run ruff format\` + auto-fix |
| \`typecheck\` | \`uv run mypy contree_mcp\` |
| \`check\` | lint + typecheck + tests |
| \`build\` | \`uv build\` |
| \`clean\` | Remove caches + build artifacts |

The long-form \`uv run\` commands are kept in the README as a fallback for contributors who don't want to use \`make\`.

## Test plan

- [x] \`make help\` prints the target list
- [x] \`make check\` runs ruff + mypy + pytest and all pass (516 tests)
- [x] \`make format\` runs without errors
- [x] No code changes — README + new Makefile only

🤖 Generated with [Claude Code](https://claude.com/claude-code)