### PR TITLE
Add CONTRIBUTING.md and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thanks for contributing! Please fill out the sections below. -->
+
+## Summary
+
+<!-- What does this PR change, and why? Keep it brief; the diff shows the "what". -->
+
+## Linked issue
+
+<!-- "Closes #123" or "Refs #123". For non-trivial changes, please open an issue first. -->
+
+## Test plan
+
+<!-- How did you verify this works? -->
+
+- [ ] `make check` passes locally (lint + typecheck + tests)
+- [ ] New behavior covered by tests
+- [ ] `README.md` updated if user-facing behavior changed
+- [ ] `llm.txt` updated if internals changed in ways agents should know
+
+## Notes for reviewers
+
+<!-- Anything reviewers should pay attention to: design trade-offs, things you considered and rejected, follow-up work. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to ConTree MCP
+
+Thanks for considering a contribution! This guide covers the practical bits — opening issues, setting up a dev environment, and getting a PR merged.
+
+## Reporting issues
+
+**Bugs.** Open a [bug report](https://github.com/nebius/contree-mcp/issues/new?template=bug_report.yml). Include `contree-mcp --version`, your Python version, OS, MCP client, a minimal reproducer, and any logs (`--log-level=debug` is helpful).
+
+**Features.** For anything beyond a small fix, please [open a feature request](https://github.com/nebius/contree-mcp/issues/new?template=feature_request.yml) **before** writing code. We may have a different shape in mind, or be working on something related.
+
+**Documentation gaps.** [Open a docs issue](https://github.com/nebius/contree-mcp/issues/new?template=documentation.yml) — small fixes can be PR'd directly.
+
+**Security.** Use [GitHub Security Advisories](https://github.com/nebius/contree-mcp/security/advisories/new) — do not file a public issue.
+
+## Development setup
+
+Requirements: Python 3.10+ and [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+git clone https://github.com/nebius/contree-mcp.git
+cd contree-mcp
+make install          # uv sync --group dev
+```
+
+## Workflow
+
+```bash
+make check            # lint + typecheck + tests (run before pushing)
+make test             # tests only
+make format           # auto-fix formatting + lint
+make help             # full target list
+```
+
+When making changes:
+
+1. Fork and create a branch — descriptive name, no convention enforced (`fix/...`, `feat/...`, `docs/...`, or anything readable).
+2. Edit code in `contree_mcp/` and tests in `tests/`.
+3. Run `make check` — must pass before opening a PR. CI runs the same matrix on Ubuntu/macOS/Windows × Python 3.10–3.14.
+4. Update `README.md` if user-facing behavior changes; update `llm.txt` if internals change in ways agents need to know.
+5. Open a PR against `master`. Link the related issue if any.
+
+## Pull request expectations
+
+- Keep PRs focused — one logical change per PR.
+- Include tests for new behavior; existing test patterns in `tests/` use `FakeResponses` for HTTP mocking.
+- Update docs in the same PR as the code change.
+- The CI suite (`tests.yml`) must pass.
+- The PR template (auto-applied) lists the merge checklist.
+
+Commit messages: short imperative subject (≤72 chars), optional body explaining the *why*. Match the existing style in `git log`.
+
+## Architecture pointers
+
+- `contree_mcp/app.py` — registers tools, prompts, resources with FastMCP
+- `contree_mcp/tools/` — one file per MCP tool
+- `contree_mcp/client.py` — async HTTP client for the ConTree API
+- `contree_mcp/resources/` — MCP resource handlers (image inspection, guides)
+- `tests/conftest.py` — fixtures (`contree_client`, `http_fake_server`, `FakeResponses`)
+- `llm.txt` — agent-readable internals reference
+
+## Code style
+
+- `ruff` for lint and format (config in `pyproject.toml`)
+- `mypy --strict` for type checking
+- Line length: 119
+
+## Release process
+
+Releases are managed by the Nebius team. Contributors don't need to bump versions in PRs.
+
+## License
+
+By contributing, you agree your contributions are licensed under [Apache 2.0](LICENSE).


### PR DESCRIPTION
## Summary

The repo has issue templates (\`bug_report.yml\`, \`feature_request.yml\`, \`documentation.yml\`) but no \`CONTRIBUTING.md\` or pull-request template. New contributors don't have a clear on-ramp.

This PR adds two files:

1. **\`CONTRIBUTING.md\`** — covers reporting issues, dev setup (\`make install\` / \`make check\`), PR expectations, architecture pointers (paths to \`client.py\`, \`tools/\`, \`conftest.py\` fixtures), and code style. Designed to read top-to-bottom in ≤2 min.

2. **\`.github/PULL_REQUEST_TEMPLATE.md\`** — auto-applied PR description with: summary, linked issue, test-plan checkbox list, reviewer notes.

## Linked issue

None — pure documentation/scaffolding.

## Test plan

- [x] No code changes
- [x] CONTRIBUTING.md links resolve (issue templates exist; LICENSE exists)
- [x] PR template will render on the next PR opened against this repo

## Notes for reviewers

- I assumed the Makefile from #8 will land before this. If #8 is rejected, drop the \`make\` references in CONTRIBUTING and substitute the long-form \`uv run\` commands.
- The PR template's \`llm.txt\` checkbox reflects the existing \`llm.txt\` convention in the repo. Drop or rephrase if it's not load-bearing for reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)